### PR TITLE
fixed #33 added toggle scripts for devices#

### DIFF
--- a/runSSH.sh
+++ b/runSSH.sh
@@ -4,18 +4,21 @@ set device [lindex $argv 0]
 
 set toggle [lindex $argv 1]
 
-
+# SSH's into the host pi and runs the deviceToggle.sh script
 spawn ssh -l pi 192.168.1.99 -p 2112 "~/Assistop/device_discovery/deviceToggle.sh $device $toggle"
 
+# If presented with a yes/no option it will input yes and then type in passed, otherwise type password
 expect {
-"(yes/no)?"
-{ send -- "yes\r"
-expect "assword:"
-
-send "T1cklecorn\r";
+	"(yes/no)?"
+	{ 
+		send -- "yes\r"
+		expect "assword:"
+		send "raspberry\r";
+	}
+	"assword:"
+	{
+		send -- "raspberry\r";
+	}
 }
-"assword:"
-{send -- "T1cklecorn\r";
-}}
 
 interact


### PR DESCRIPTION
Modifies Dockerfile to have docker install expect, which we use to execute a SSH command from docker to the physical machine (the Pi) which then modifies the iptables to block or allow whatever ip address it is fed.